### PR TITLE
Save policy path

### DIFF
--- a/crates/smartvaults-core/src/policy/mod.rs
+++ b/crates/smartvaults-core/src/policy/mod.rs
@@ -793,7 +793,7 @@ impl Policy {
                 builder.add_utxos(&utxos)?;
             }
 
-            if let Some(path) = policy_path {
+            if let Some(path) = policy_path.clone() {
                 builder.policy_path(path, KeychainKind::External);
             }
 
@@ -860,6 +860,7 @@ impl Policy {
             amount,
             description,
             psbt,
+            policy_path,
         ))
     }
 

--- a/crates/smartvaults-core/src/proposal/mod.rs
+++ b/crates/smartvaults-core/src/proposal/mod.rs
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license
 
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::fmt;
 
 use keechain_core::bdk::signer::{SignerError, SignerWrapper};
@@ -86,6 +87,7 @@ pub enum Proposal {
             deserialize_with = "deserialize_psbt"
         )]
         psbt: PartiallySignedTransaction,
+        policy_path: Option<BTreeMap<String, Vec<usize>>>,
     },
     ProofOfReserve {
         descriptor: Descriptor<String>,
@@ -108,6 +110,7 @@ pub enum Proposal {
             deserialize_with = "deserialize_psbt"
         )]
         psbt: PartiallySignedTransaction,
+        policy_path: Option<BTreeMap<String, Vec<usize>>>,
     },
 }
 
@@ -130,6 +133,7 @@ impl Proposal {
         amount: u64,
         description: S,
         psbt: PartiallySignedTransaction,
+        policy_path: Option<BTreeMap<String, Vec<usize>>>,
     ) -> Self
     where
         S: Into<String>,
@@ -140,6 +144,7 @@ impl Proposal {
             amount,
             description: description.into(),
             psbt,
+            policy_path,
         }
     }
 
@@ -165,6 +170,7 @@ impl Proposal {
         description: S,
         period: Period,
         psbt: PartiallySignedTransaction,
+        policy_path: Option<BTreeMap<String, Vec<usize>>>,
     ) -> Self
     where
         S: Into<String>,
@@ -176,6 +182,7 @@ impl Proposal {
             description: description.into(),
             period,
             psbt,
+            policy_path,
         }
     }
 

--- a/crates/smartvaults-sdk/src/client/key_agent.rs
+++ b/crates/smartvaults-sdk/src/client/key_agent.rs
@@ -242,7 +242,7 @@ impl SmartVaults {
                 description,
                 fee_rate,
                 utxos,
-                policy_path,
+                policy_path.clone(),
                 skip_frozen_utxos,
             )
             .await?;
@@ -261,6 +261,7 @@ impl SmartVaults {
                 description,
                 period,
                 psbt,
+                policy_path,
             };
             Ok(prop)
         } else {


### PR DESCRIPTION
Adds `policy_path` to spending and key agent payment proposals, needed to determine the expected signers for some proposals.